### PR TITLE
fix: handle duplicate surveys and mismatched survey/participants

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -48,7 +48,7 @@ source("R/tournament.R")
 # │       └── README.md
 
 
-tournament_dir <- "2022-02"
+tournament_dir <- "2023-11"
 max_game_rounds <- 15
 # max_game_rounds should be inferred ?
 tournament <- tournament_load(tournament_dir, max_game_rounds) 

--- a/R/tournament.R
+++ b/R/tournament.R
@@ -9,10 +9,16 @@ tournament_load <- function(tournament_dir, max_game_rounds) {
     game_tournament_keys = game_tournament %>% 
       dplyr::select(tournament, tournament_round, participant_id, invite_id))
   
-  assertthat::assert_that(nrow(game_tournament) == nrow(survey_tournament))
-  
-  game_tournament %>%
-    dplyr::inner_join(survey_tournament, by = c("tournament", "tournament_round", "participant_id", "invite_id"))
+  if (nrow(game_tournament) == nrow(survey_tournament)) {
+    return(game_tournament %>%
+      dplyr::inner_join(survey_tournament, by = c("tournament", "tournament_round", "participant_id", "invite_id"))
+    )
+  } else {
+    warning("Game records and survey records do not match, consider checking for duplicates or missing rows")
+    return(game_tournament %>%
+      dplyr::left_join(survey_tournament, by = c("tournament", "tournament_round", "participant_id", "invite_id"))
+    )
+  }
 }
 
 tournament_write <- function(tournament_dir, tournament) {


### PR DESCRIPTION
Putting this up as a possible way to handle the broken data without losing full games by throwing a warning and doing a left join if we have mismatched game and survey data. Requires manually assigning a new participant id and invite id to one of the duplicate participant records, which serves as a marker for where this occurred in the end

Also fixes the issues with survey processing (removing extra surveys for participants, switching to `bind_rows()` to revert to previous functionality)

Gets us out of this hole and I figure any further effort is probably better placed towards redoing this with pandas.. Lmk if this seems alright @alee, or if you have a diff solution already